### PR TITLE
fix notice "Undefined offset: 2", add support Bing Optimized IE

### DIFF
--- a/src/Woothee/AgentCategory/Browser/Msie.php
+++ b/src/Woothee/AgentCategory/Browser/Msie.php
@@ -13,7 +13,7 @@ class Msie extends AbstractCategory
 
             if (preg_match('/MSIE ([.0-9]+);/', $ua, $matches) === 1) {
                 $version = $matches[1];
-            } elseif (preg_match('/Trident\/([.0-9]+); rv:([.0-9]+)/', $ua, $matches) === 1) {
+            } elseif (preg_match('/Trident\/([.0-9]+);(?: BOIE[0-9]+;[A-Z]+;)? rv:([.0-9]+)/', $ua, $matches) === 1) {
                 $version = $matches[2];
             }
 


### PR DESCRIPTION
"Notice: Undefined offset: 2" in Woothee\AgentCategory\Browser\Msie.php on line 17

MSIE11 (Bing Optimized) + Windows 7
Mozilla/5.0 (Windows NT 6.1; Trident/7.0; BOIE9;JAJP; rv:11.0) like Gecko
