### PR TITLE
fix lack of result hash key which is 'os_version' when parsed failed

### DIFF
--- a/tests/Woothee/Tests/ClassifierTest.php
+++ b/tests/Woothee/Tests/ClassifierTest.php
@@ -110,6 +110,21 @@ class ClassifierTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->classifier->tryMobilePhone($ua, $result));
     }
 
+    /**
+     * @test
+     * confirm when invalid UserAgent string
+     */
+    public function testNeverExistingParseResult()
+    {
+        $ua = 'never%existing$user&agent';
+        $result = $this->classifier->parse($ua);
+
+        $resultKeys = \Woothee\Dataset::$ATTRIBUTE_LIST;
+        foreach ($resultKeys as $key) {
+            $this->assertSame(\Woothee\Dataset::VALUE_UNKNOWN, $result[$key]);
+        }
+    }
+
     private function loadTestSetYaml($file)
     {
         $files = func_get_args();


### PR DESCRIPTION
fix bug when https://github.com/woothee/woothee-php/pull/12/files