### PR TITLE
Remove daed code for iOS

### DIFF
--- a/src/AgentCategory/Os/Osx.php
+++ b/src/AgentCategory/Os/Osx.php
@@ -16,17 +16,7 @@ class Osx extends AbstractCategory
         $version = null;
 
         if (strpos($ua, 'like Mac OS X') !== false) {
-            if (strpos($ua, 'iPhone;') !== false) {
-                $data = DataSet::get('iPhone');
-            } elseif (strpos($ua, 'iPad') !== false) {
-                $data = DataSet::get('iPad');
-            } elseif (strpos($ua, 'iPod') !== false) {
-                $data = DataSet::get('iPod');
-            }
-
-            if (preg_match('/; CPU(?: iPhone)? OS (\\d+_\\d+(?:_\\d+)?) like Mac OS X/', $ua, $matches) === 1) {
-                $version = str_replace('_', '.', $matches[1]);
-            }
+            return false;
         } else {
             if (preg_match('/Mac OS X (10[._]\\d+(?:[._]\\d+)?)(?:\\)|;)/', $ua, $matches) === 1) {
                 $version = str_replace('_', '.', $matches[1]);

--- a/src/AgentCategory/Os/SmartPhone.php
+++ b/src/AgentCategory/Os/SmartPhone.php
@@ -11,12 +11,15 @@ class SmartPhone extends AbstractCategory
         $data = null;
         $version = null;
 
-        if (strpos($ua, 'iPhone') !== false) {
-            $data = DataSet::get('iPhone');
+        if (strpos($ua, 'iPod') !== false) {
+            $data = DataSet::get('iPod');
+            $version = static::parseIosVersion($ua);
         } elseif (strpos($ua, 'iPad') !== false) {
             $data = DataSet::get('iPad');
-        } elseif (strpos($ua, 'iPod') !== false) {
-            $data = DataSet::get('iPod');
+            $version = static::parseIosVersion($ua);
+        } elseif (strpos($ua, 'iPhone') !== false) {
+            $data = DataSet::get('iPhone');
+            $version = static::parseIosVersion($ua);
         } elseif (strpos($ua, 'Android') !== false) {
             $data = DataSet::get('Android');
         } elseif (strpos($ua, 'CFNetwork') !== false) {
@@ -47,5 +50,12 @@ class SmartPhone extends AbstractCategory
         }
 
         return true;
+    }
+
+    private static function parseIosVersion($ua)
+    {
+        if (preg_match('/; CPU(?: iPhone)? OS (\\d+_\\d+(?:_\\d+)?) like Mac OS X/', $ua, $matches) === 1) {
+            return str_replace('_', '.', $matches[1]);
+        }
     }
 }


### PR DESCRIPTION
iPhone/iPod/iPad detection is implemented in src/AgentCategory/Os/SmartPhone.php.
So remove from src/AgentCategory/Os/Osx.php.