### PR TITLE
Fix coding format

### DIFF
--- a/src/AgentCategory/AbstractCategory.php
+++ b/src/AgentCategory/AbstractCategory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory;
 
 use Woothee\DataSet;

--- a/src/AgentCategory/Appliance/DigitalTv.php
+++ b/src/AgentCategory/Appliance/DigitalTv.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Appliance;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Appliance/Nintendo.php
+++ b/src/AgentCategory/Appliance/Nintendo.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Appliance;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Appliance/Playstation.php
+++ b/src/AgentCategory/Appliance/Playstation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Appliance;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Browser/Firefox.php
+++ b/src/AgentCategory/Browser/Firefox.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Browser;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Browser/Msie.php
+++ b/src/AgentCategory/Browser/Msie.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Browser;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Browser/Opera.php
+++ b/src/AgentCategory/Browser/Opera.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Browser;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Browser/SafariChrome.php
+++ b/src/AgentCategory/Browser/SafariChrome.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Browser;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Browser/Sleipnir.php
+++ b/src/AgentCategory/Browser/Sleipnir.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Browser;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Crawler/Crawlers.php
+++ b/src/AgentCategory/Crawler/Crawlers.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Crawler;
 
 use Woothee\AgentCategory\AbstractCategory;
@@ -10,7 +11,7 @@ class Crawlers extends AbstractCategory
     {
         if (strpos($ua, 'Yahoo') !== false
             || strpos($ua, 'help.yahoo.co.jp/help/jp/') !== false
-            || strpos($ua, 'listing.yahoo.co.jp/support/faq/') !== false ) {
+            || strpos($ua, 'listing.yahoo.co.jp/support/faq/') !== false) {
             if (strpos($ua, 'compatible; Yahoo! Slurp') !== false) {
                 static::updateMap($result, DataSet::get('YahooSlurp'));
 

--- a/src/AgentCategory/Crawler/Google.php
+++ b/src/AgentCategory/Crawler/Google.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Crawler;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Crawler/MayBeCrawler.php
+++ b/src/AgentCategory/Crawler/MayBeCrawler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Crawler;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Misc/DesktopTools.php
+++ b/src/AgentCategory/Misc/DesktopTools.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Misc;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Misc/HttpLibrary.php
+++ b/src/AgentCategory/Misc/HttpLibrary.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Misc;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Misc/MayBeRssReader.php
+++ b/src/AgentCategory/Misc/MayBeRssReader.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Misc;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/MobilePhone/Au.php
+++ b/src/AgentCategory/MobilePhone/Au.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\MobilePhone;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/MobilePhone/Docomo.php
+++ b/src/AgentCategory/MobilePhone/Docomo.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\MobilePhone;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/MobilePhone/MiscPhones.php
+++ b/src/AgentCategory/MobilePhone/MiscPhones.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\MobilePhone;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/MobilePhone/Softbank.php
+++ b/src/AgentCategory/MobilePhone/Softbank.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\MobilePhone;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/MobilePhone/Willcom.php
+++ b/src/AgentCategory/MobilePhone/Willcom.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\MobilePhone;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Os/Appliance.php
+++ b/src/AgentCategory/Os/Appliance.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Os;
 
 use Woothee\AgentCategory\AbstractCategory;
@@ -8,8 +9,8 @@ class Appliance extends AbstractCategory
 {
     public static function challenge($ua, &$result)
     {
-        if (strpos($ua, "Nintendo DSi;") !== false) {
-            $data = DataSet::get("NintendoDSi");
+        if (strpos($ua, 'Nintendo DSi;') !== false) {
+            $data = DataSet::get('NintendoDSi');
 
             static::updateCategory($result, $data[DataSet::DATASET_KEY_CATEGORY]);
             static::updateOs($result, $data[DataSet::DATASET_KEY_OS]);
@@ -17,8 +18,8 @@ class Appliance extends AbstractCategory
             return true;
         }
 
-        if (strpos($ua, "Nintendo Wii;") !== false) {
-            $data = DataSet::get("NintendoWii");
+        if (strpos($ua, 'Nintendo Wii;') !== false) {
+            $data = DataSet::get('NintendoWii');
 
             static::updateCategory($result, $data[DataSet::DATASET_KEY_CATEGORY]);
             static::updateOs($result, $data[DataSet::DATASET_KEY_OS]);

--- a/src/AgentCategory/Os/Linux.php
+++ b/src/AgentCategory/Os/Linux.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Os;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Os/MiscOs.php
+++ b/src/AgentCategory/Os/MiscOs.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Os;
 
 use Woothee\AgentCategory\AbstractCategory;
@@ -13,7 +14,7 @@ class MiscOs extends AbstractCategory
 
         if (strpos($ua, '(Win98;') > -1) {
             $data = DataSet::get('Win98');
-            $os_version = "98";
+            $os_version = '98';
         } elseif (strpos($ua, 'Macintosh; U; PPC;') > -1 || strpos($ua, 'Mac_PowerPC') > -1) {
             $data = DataSet::get('MacOS');
             if (preg_match('/rv:(\\d+\\.\\d+\\.\\d+)/', $ua, $matches) === 1) {

--- a/src/AgentCategory/Os/MobilePhone.php
+++ b/src/AgentCategory/Os/MobilePhone.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Os;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Os/Osx.php
+++ b/src/AgentCategory/Os/Osx.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Os;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Os/SmartPhone.php
+++ b/src/AgentCategory/Os/SmartPhone.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Os;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/AgentCategory/Os/Windows.php
+++ b/src/AgentCategory/Os/Windows.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\AgentCategory\Os;
 
 use Woothee\AgentCategory\AbstractCategory;

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee;
 
 use Woothee\AgentCategory\Appliance\DigitalTv;

--- a/tests/Woothee/Tests/AgentCategory/Os/WindowsTest.php
+++ b/tests/Woothee/Tests/AgentCategory/Os/WindowsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\Tests\AgentCategory\Os;
 
 use Woothee\AgentCategory\Os\Windows;

--- a/tests/Woothee/Tests/ClassifierTest.php
+++ b/tests/Woothee/Tests/ClassifierTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Woothee\Tests;
 
 use Symfony\Component\Yaml\Yaml;
@@ -8,7 +9,7 @@ class ClassifierTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->classifier = new Classifier;
+        $this->classifier = new Classifier();
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,3 @@
 <?php
+
 error_reporting(E_ALL);


### PR DESCRIPTION
Fix coding format by PHP CS Fixer.

```
./vendor/bin/php-cs-fixer fix src
./vendor/bin/php-cs-fixer fix tests
```

Skip modifying ``src/DataSet.php`` because these file is generated by script.

No logic changes.