### PR TITLE
Catch up with woothee v1.8.0

### DIFF
--- a/src/AgentCategory/Browser/YandexBrowser.php
+++ b/src/AgentCategory/Browser/YandexBrowser.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Woothee\AgentCategory\Browser;
+
+use Woothee\AgentCategory\AbstractCategory;
+use Woothee\DataSet;
+
+class YandexBrowser extends AbstractCategory
+{
+    public static function challenge($ua, &$result)
+    {
+        if (strpos($ua, 'YaBrowser/') === false) {
+            return false;
+        }
+
+        $version = DataSet::VALUE_UNKNOWN;
+
+        if (preg_match('/YaBrowser\/([.0-9]+)/Du', $ua, $matches)) {
+            $version = $matches[1];
+        }
+
+        static::updateMap($result, DataSet::get('YaBrowser'));
+        static::updateVersion($result, $version);
+
+        return true;
+    }
+}
+

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -34,7 +34,7 @@ use Woothee\AgentCategory\Os\Windows;
 
 class Classifier
 {
-    const VERSION = '1.7.0';
+    const VERSION = '1.8.0';
 
     public function isCrawler($ua)
     {

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -11,6 +11,7 @@ use Woothee\AgentCategory\Browser\Opera;
 use Woothee\AgentCategory\Browser\SafariChrome;
 use Woothee\AgentCategory\Browser\Sleipnir;
 use Woothee\AgentCategory\Browser\Vivaldi;
+use Woothee\AgentCategory\Browser\YandexBrowser;
 use Woothee\AgentCategory\Browser\Webview;
 use Woothee\AgentCategory\Crawler\Crawlers;
 use Woothee\AgentCategory\Crawler\Google;
@@ -68,6 +69,10 @@ class Classifier
         }
 
         if (Vivaldi::challenge($ua, $result)) {
+            return true;
+        }
+
+        if (YandexBrowser::challenge($ua, $result)) {
             return true;
         }
 

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -1,7 +1,7 @@
 <?php
 namespace Woothee;
 
-// GENERATED from dataset.yml at Sat Apr 29 16:02:46 JST 2017 by yuya
+// GENERATED from dataset.yml at Sun Jul 22 02:46:33 JST 2018 by tell_k
 class DataSet
 {
     const DATASET_KEY_LABEL            = 'label';
@@ -105,6 +105,12 @@ class DataSet
             'name'     => 'Webview',
             'type'     => 'browser',
             'vendor'   => 'OS vendor',
+        ),
+        'YaBrowser' => array(
+            'label'    => 'YaBrowser',
+            'name'     => 'Yandex Browser',
+            'type'     => 'browser',
+            'vendor'   => 'Yandex',
         ),
         'Win' => array(
             'label'    => 'Win',


### PR DESCRIPTION
I've catched up with woothee v1.8.0.

- Add YandexBrowser

FYI.  In my travis environment the following error was displayed.

- https://travis-ci.org/tell-k/woothee-php/jobs/406775215
- I think you need to fix .travis.ini :) 

```
PHP 5.3 is supported only on Precise.
See https://docs.travis-ci.com/user/reference/trusty#PHP-images on how to test PHP 5.3 on Precise.
```

Please feel free to merge it. Thx.