### PR TITLE
Fix fail test on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
+  - 7.2
   - hhvm
 
 matrix:
   allow_failures:
-    - php: 7
+    - php: 5.4
+    - php: 5.5
     - php: hhvm
 
 before_script:


### PR DESCRIPTION
fail test with PHP5.3 on travis-ci. https://github.com/woothee/woothee-php/pull/38#issue-203047985

update travis-ci settings yaml file:

* drop PHP5.3
* add support version PHP7.1, and 7.2
* allow failuer PHP5.4 and PHP5.5

see also:
http://php.net/supported-versions.php