### PR TITLE
Re-add PHP 5.3 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ php:
   - hhvm
 
 matrix:
+  include:
+    - php: 5.3
+      dist: precise
   allow_failures:
     - php: 5.4
     - php: 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - php: 5.3
       dist: precise
   allow_failures:
+    - php: 5.3
     - php: 5.4
     - php: 5.5
     - php: hhvm


### PR DESCRIPTION
In #39, fixed PHP 5.3 test error in Travis-CI.
But, I reconfigure PHP 5.3 test.
Because woothee-php support PHP version 5.3.3 or higher.

Dropping PHP 5.3 support is braking change, so I would like to do it with major version.