### PR TITLE
Enable Travis CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
     - php: 5.5
     - php: hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_script:
   - composer install
 


### PR DESCRIPTION
Enable Travis CI cache.
The build speed has improved slightly.

Before:

About 8 to 11 minutes

After:

About 8 minutes.

![2018-09-24_23-41-40](https://user-images.githubusercontent.com/74355/45959013-dac59300-c053-11e8-9dc3-f2fae01138f5.png)
