### PR TITLE
Drop support for PHP version < 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,12 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - hhvm
 
 matrix:
-  include:
-    - php: 5.3
-      dist: precise
   allow_failures:
-    - php: 5.3
-    - php: 5.4
-    - php: 5.5
     - php: hhvm
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">= 5.3.3"
+        "php": ">= 7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",


### PR DESCRIPTION
- Support for PHP 5.5 or lower is already stopped
- Security support for PHP 5.6, 7.0 will also end this year
- Major libraries and frameworks are support for PHP 7.1 or higher
  - https://packagist.org/packages/laravel/laravel
  - https://packagist.org/packages/symfony/symfony
  - https://packagist.org/packages/phpunit/phpunit
